### PR TITLE
Updated deprecated Class.newInstance() method in LinkedObjectPool

### DIFF
--- a/src/main/java/com/coralblocks/coralme/util/LinkedObjectPool.java
+++ b/src/main/java/com/coralblocks/coralme/util/LinkedObjectPool.java
@@ -41,7 +41,7 @@ public class LinkedObjectPool<E> implements ObjectPool<E> {
 			@Override
 			public E newInstance() {
 				try {
-					return klass.newInstance();
+					return klass.getDeclaredConstructor().newInstance();
 				} catch (Exception e) {
 					throw new RuntimeException(e);
 				}


### PR DESCRIPTION
Updated deprecated Class.newInstance() method in LinkedObjectPool as described in issue #10.